### PR TITLE
#426  侧边栏文章标题默认取front matter的title

### DIFF
--- a/theme-vdoing/node_utils/getSidebarData.js
+++ b/theme-vdoing/node_utils/getSidebarData.js
@@ -133,7 +133,12 @@ function mapTocToSidebar (root, collapsable, prefix) {
       const contentStr = fs.readFileSync(file, 'utf8') // 读取md文件内容，返回字符串
       const { data } = matter(contentStr) // 解析出front matter数据
       const permalink = data.permalink || ''
-      sidebar[order] = [prefix + filename, title, permalink];  // [<路径>, <文件标题>, <永久链接>]
+      const title2 = data.title || title
+	    if (title2) {
+		    sidebar[order] = [prefix + filename, title2, permalink];  // [<路径>, <front matter.title>, <永久链接>]
+	    } else {
+		    sidebar[order] = [prefix + filename, title, permalink];  // [<路径>, <文件标题>, <永久链接>]
+	   }
 
       // 目录页和永久链接，用于给面包屑提供数据
       const pageComponent = data.pageComponent


### PR DESCRIPTION
解决issue #426 ，从 front matter 提取 title 作为侧边栏文章的标题，这样可以与文章标题本身是front matter title相对应。如果没有定义front matter title，则使用文件名。