### PR TITLE
[新增]  鼠標滑動到左側邊彈出側邊欄的功能

### DIFF
--- a/docs/.vuepress/config/themeConfig.js
+++ b/docs/.vuepress/config/themeConfig.js
@@ -42,6 +42,7 @@ module.exports = {
   // rightMenuBar: false, // 是否显示右侧文章大纲栏，默认true (屏宽小于1300px下无论如何都不显示)
   // sidebarOpen: false, // 初始状态是否打开侧边栏，默认true
   // pageButton: false, // 是否显示快捷翻页按钮，默认true
+  // sidebarHoverTriggerOpen: false, // 当侧边栏关闭时，是否允许鼠标滑动到左侧边弹出侧边栏，默认true
 
   sidebar: 'structuring', // 侧边栏  'structuring' | { mode: 'structuring', collapsable: Boolean} | 'auto' | 自定义    温馨提示：目录页数据依赖于结构化的侧边栏数据，如果你不设置为'structuring',将无法使用目录页
 

--- a/theme-vdoing/layouts/Layout.vue
+++ b/theme-vdoing/layouts/Layout.vue
@@ -15,6 +15,11 @@
       @click="toggleSidebar(false)"
     ></div>
 
+    <div
+      v-if="$themeConfig.sidebarHoverTriggerOpen !== false"
+      class="sidebar-hover-trigger"
+    ></div>
+
     <Sidebar
       :items="sidebarItems"
       @toggle-sidebar="toggleSidebar"

--- a/theme-vdoing/styles/index.styl
+++ b/theme-vdoing/styles/index.styl
@@ -97,6 +97,15 @@ body .search-box
   height 100vh
   display none
 
+.sidebar-hover-trigger
+  display none
+  position: fixed
+  z-index 12
+  top ($navbarHeight + 4.5rem)
+  left 0
+  bottom 0
+  width 24px
+
 .sidebar
   font-size 16px
   background-color var(--sidebarBg)

--- a/theme-vdoing/styles/mobile.styl
+++ b/theme-vdoing/styles/mobile.styl
@@ -51,6 +51,17 @@ $mobileSidebarWidth = $sidebarWidth * 0.9
 // 侧边栏显示隐藏的适配
 @media (min-width: ($MQMobile + 1px)) // 720px
   .theme-container
+    .sidebar-hover-trigger
+      display: block
+    .sidebar-hover-trigger:hover ~ .sidebar
+      transform translateX(0)
+      z-index: 100
+
+    &:not(.sidebar-open)
+      .sidebar-hover-trigger ~ .sidebar:hover
+        transform translateX(0)
+        z-index: 100
+
     &.sidebar-open
       .sidebar-mask
         display: none
@@ -61,12 +72,24 @@ $mobileSidebarWidth = $sidebarWidth * 0.9
       .page
         padding-left ($sidebarWidth + .8rem)
         padding-right .8rem
+      .sidebar-hover-trigger
+        display: none
+
     &.have-rightmenu
       .page
         padding-right ($rightMenuWidth + 20rem)
     &.no-sidebar
       .page
         padding-left 0!important
+      .sidebar-hover-trigger
+        display: none
+
+    &.hide-navbar
+      .sidebar-hover-trigger
+        top 4.5rem
+      .sidebar
+        top 0
+
   @media (max-width: $MQNarrow)
     .theme-container
       &.sidebar-open:not(.on-sidebar)


### PR DESCRIPTION
【新增】：當側邊欄關閉時，是否允許鼠標滑動到左側邊彈出側邊欄的功能
【目的】：當在專注閱讀模式時，我會關閉側邊欄。而當想要快速檢索目錄或是切換頁面時，不想一直開開關關側邊欄 sidebar，這時候鼠標滑動彈出側邊欄的方式會很有平滑的檢索感受。 (靈感來自 Notion & Jira 的側邊欄效果)
【優點】：
  - 有實作開關 themeConfig. `sidebarHoverTriggerOpen` ，可以自由關閉此功能
  - 只使用 CSS 來實現此功能
  - 只有在 720px 屏幕以上才會有此功能，避免小螢幕尺寸誤觸

【用法】：

![new1](https://user-images.githubusercontent.com/15682657/139426148-2de75754-d0e5-4c36-83a9-d4370f5c7d96.gif)
![new2](https://user-images.githubusercontent.com/15682657/139426181-0908bac6-6ac3-4fb2-ad7d-8c4e14689e76.gif)
