### PR TITLE
fix: canonicalLink on ssr template

### DIFF
--- a/theme-vdoing/templates/ssr.html
+++ b/theme-vdoing/templates/ssr.html
@@ -7,6 +7,7 @@
     <meta name="generator" content="VuePress {{ version }}">
     {{{ userHeadTags }}}
     {{{ pageMeta }}}
+    {{{ canonicalLink }}}
     {{{ renderResourceHints() }}}
     {{{ renderStyles() }}}
   </head>


### PR DESCRIPTION
- 修復 ssr.html template 未加入 `{{{ canonicalLink }}}` ，參考[官方原始碼文檔](https://github.com/vuejs/vuepress/blob/master/packages/%40vuepress/core/lib/client/index.ssr.html#L10)
- front matter 上的一個參數值  [canonicalUrl](https://vuepress.vuejs.org/guide/frontmatter.html#canonicalurl) 與此有關聯