### PR TITLE
解决存在二级下拉导航时不能使用 http 地址问题

### DIFF
--- a/vdoing/components/DropdownLink.vue
+++ b/vdoing/components/DropdownLink.vue
@@ -6,9 +6,7 @@
       :aria-label="dropdownAriaLabel"
       @click="toggle"
     >
-      <router-link v-if="item.link" :to="item.link" class="link-title">{{
-        item.text
-      }}</router-link>
+      <NavLink :item="item" />
       <span class="title" v-show="!item.link">{{ item.text }}</span>
       <span class="arrow" :class="open ? 'down' : 'right'"></span>
     </button>


### PR DESCRIPTION
举例：（修改前）
```
 {
    text: '📦仓库', link: 'https://gitee.com/xxxx', items: [
      {text: 'Gitee', link: 'https://gitee.com/xxxx'},
      {text: 'Github', link: 'https://github.com/xxxx'},
    ]
  },
```

页面渲染：

https://xxxx.com/https://gitee.com/xxxx


修改后使用统一组件实现判断 url 渲染不通的标签
